### PR TITLE
fix: disable Express ETag to prevent nginx from returning 304 on POST…

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,9 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  // Desactiva ETag en Express para evitar que nginx devuelva 304 en POST
+  app.getHttpAdapter().getInstance().set('etag', false);
+
   // Configuración global de CORS
   app.enableCors({
     origin: true, // agrega aquí los dominios permitidos


### PR DESCRIPTION
… requests

Express.js auto-generates ETag headers; nginx caches them and returns 304 Not Modified on repeated POST bodies instead of 201 Created. Disabling etag removes the header so nginx always forwards to the app.